### PR TITLE
Support multiple signing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64",
+ "bytes",
  "clap",
  "color-eyre",
  "dryoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 axum = "0.6.20"
 base64 = "0.21.4"
+bytes = "1.5.0"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 color-eyre = { version = "0.6.2", default-features = false, features = ["issue-url", "tracing-error", "capture-spantrace", "color-spantrace"] }
 dryoc = "0.5.1"

--- a/src/cli/instrumentation.rs
+++ b/src/cli/instrumentation.rs
@@ -75,7 +75,7 @@ impl Instrumentation {
                 }
                 // If the `--log-directives` is specified, don't set a default
                 if self.log_directives.is_empty() {
-                    EnvFilter::try_new(&format!(
+                    EnvFilter::try_new(format!(
                         "{}={}",
                         env!("CARGO_PKG_NAME").replace('-', "_"),
                         self.log_level()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,14 +5,14 @@ use clap::Parser;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[clap(version)]
 pub struct Cli {
     #[clap(long, default_value_t = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 8080))]
     pub bind: SocketAddr,
 
     #[clap(long)]
-    pub secret_key_file: PathBuf,
+    pub secret_key_files: Vec<PathBuf>,
 
     #[clap(flatten)]
     pub instrumentation: instrumentation::Instrumentation,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,8 @@ mod logger;
 
 use clap::Parser;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
-use std::path::PathBuf;
+
+use crate::nix::NixPrivateKeyPath;
 
 #[derive(Debug, Parser)]
 #[clap(version)]
@@ -12,7 +13,7 @@ pub struct Cli {
     pub bind: SocketAddr,
 
     #[clap(long)]
-    pub secret_key_files: Vec<PathBuf>,
+    pub secret_key_files: Vec<NixPrivateKeyPath>,
 
     #[clap(flatten)]
     pub instrumentation: instrumentation::Instrumentation,

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,11 +110,13 @@ async fn main() -> Result<()> {
         .on_request(trace_layer::trace_layer_on_request)
         .on_response(trace_layer::trace_layer_on_response);
 
-    let app = Router::new()
+    let v1 = Router::new()
         .route("/sign", post(sign))
         .route("/sign-store-path", post(sign_store_path))
         .route("/publickey", get(public_key))
-        .with_state(ctx.clone())
+        .with_state(ctx.clone());
+    let app = Router::new()
+        .nest("/_api/v1", v1)
         .fallback(not_found)
         .layer(trace_layer);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn secret_key_to_public_key(secret_key_file_contents: &str) -> Result<NixPublicK
         [u8; CRYPTO_SIGN_ED25519_SECRETKEYBYTES],
     > = SigningKeyPair::from_secret_key(secret_key);
 
-    let public_key_base64 = STANDARD.encode(&signing_pair.public_key);
+    let public_key_base64 = STANDARD.encode(signing_pair.public_key);
 
     Ok(NixPublicKey {
         name: key_name,
@@ -220,9 +220,9 @@ async fn sign_fingerprint_with_keys(
     let mut signatures = HashSet::new();
 
     for secret_key_path in keypairs.values() {
-        let encoded_secret_key = AppContextInner::get_secret_contents(&secret_key_path).await?;
+        let encoded_secret_key = AppContextInner::get_secret_contents(secret_key_path).await?;
         let signature =
-            sign_fingerprint_with_secret_key(&fingerprint_bytes, &encoded_secret_key).await?;
+            sign_fingerprint_with_secret_key(fingerprint_bytes, &encoded_secret_key).await?;
         signatures.insert(signature);
     }
 
@@ -243,7 +243,7 @@ async fn sign_fingerprint_with_secret_key(
 
     dryoc::classic::crypto_sign::crypto_sign_detached(
         &mut signature_bytes,
-        &fingerprint,
+        fingerprint,
         &secret_key,
     )?;
 

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,8 +1,34 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
 use serde::Deserialize as _;
 
 use crate::error::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct NixPublicKey {
+    pub(crate) name: String,
+    pub(crate) key: String,
+}
+
+impl std::fmt::Display for NixPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}:{}", self.name, self.key))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NixPrivateKeyPath(pub(crate) PathBuf);
+
+impl From<&std::ffi::OsStr> for NixPrivateKeyPath {
+    fn from(value: &std::ffi::OsStr) -> Self {
+        Self(value.into())
+    }
+}
+
+pub(crate) type NixKeypairMap = HashMap<NixPublicKey, NixPrivateKeyPath>;
 
 #[derive(Debug, Clone, serde_derive::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -76,7 +76,7 @@ impl ToString for NixBase32 {
 impl SRIHash {
     // https://github.com/NixOS/nix/blob/78e886bc5fd9e4d85f8503799540c0b71bb270be/src/libutil/hash.cc#L85
     // ommitted: E O U T
-    pub const BASE32_CHARS: &[u8] = b"0123456789abcdfghijklmnpqrsvwxyz";
+    pub const BASE32_CHARS: &'static [u8] = b"0123456789abcdfghijklmnpqrsvwxyz";
 
     // Adapted from:
     // https://github.com/NixOS/nix/blob/78e886bc5fd9e4d85f8503799540c0b71bb270be/src/libutil/hash.cc#L88-L108

--- a/src/test.rs
+++ b/src/test.rs
@@ -66,5 +66,5 @@ async fn test_fingerprint_signing() {
 #[test]
 fn test_pubkey_generation() {
     let public_key = super::secret_key_to_public_key(SECRET_KEY_FILE_CONTENTS).unwrap();
-    assert_eq!(public_key, PUBLIC_KEY_FILE_CONTENTS);
+    assert_eq!(public_key.to_string(), PUBLIC_KEY_FILE_CONTENTS);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -53,9 +53,10 @@ fn test_fingerprint_generation() {
 async fn test_fingerprint_signing() {
     let path_info = test_path_info();
     let fingerprint = path_info.fingerprint().unwrap();
+    let fingerprint = bytes::Bytes::from(fingerprint);
 
     let expected_signature = "test-1:TS12zri2hld72xAwjPUyL0MGqcmbWtHuAFFoRCXu6PwFVd0Awqe4+wgENU7XbWm/itTWumccNX+c7DVFZqKVCA==";
-    let signature = super::sign_fingerprint(SECRET_KEY_FILE_CONTENTS, fingerprint.into())
+    let signature = super::sign_fingerprint_with_secret_key(&fingerprint, SECRET_KEY_FILE_CONTENTS)
         .await
         .expect("should have gotten a fingerprint");
 


### PR DESCRIPTION
While the NixOS cache only signs with one key right now, in the future we may want to use multiple keys (i.e. to enable some sort of key rotation: sign with both keys for a while, retire and untrust old key, bam things still continue to work except for people who haven't updated in a while).

This also versions the API such that even if this does become "stable", we can provide whatever changes we want over a different version.

I contemplated doing some sort of magical API version resolving (i.e. use a special header to allow requesters to get a specific version, or the latest if unspecified), but I feel like this won't change nearly enough for that to be useful.

Note that this "breaks" the initial implementation in that the response to `/_api/v1/sign` is now a JSON blob of `{"signatures":["key1:djklsajlkdsa==","key2:dasjkldsjakl=="]}` instead of a string of a single signature. Same with `/publickeys` (which was also renamed, `/publickey` -> `/publickeys`) which now returns a JSON blob of `{"public_keys":{"key1":"base64_pubkey1","key2":"base64_pubkey2"}}`.

cc @RaitoBezarius -- probably necessitates some updates to your Nix PR to hit the proper endpoints now that they're moved behind `/_api/v1`.

---

TODO:
- [ ] update the nixos tests
- [ ] think about if the `signatures` document should be similarly "decoupled" so that requesters can look up the specific signing key they want  (i.e. an object `{"key1":"djksaljdklsa=="}` instead of a string `"key1:jsdkaljdlksa=="`)
- [ ] think about if the `public_keys` document should store the entire public key (including name) under the `key1` object like `"key1":"key1:dsajkldjkasl=="` or not